### PR TITLE
Separate fantasy team and player endpoints

### DIFF
--- a/api/gameweek_stats/__init__.py
+++ b/api/gameweek_stats/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from .views import GameWeekStatsView, TeamOfWeekView
+from .views import GameWeekStatsView, TeamOfWeekView, GameWeekStatsFantasyView
 
 gameweek_stats_blueprint = Blueprint(
     'gameweek_stats', __name__, url_prefix='/api/v1')
@@ -9,13 +9,15 @@ gameweek_stats_blueprint.add_url_rule(
     '/gameweek_stats/<game_week_id>', view_func=gameweek_stats_view,
     methods=['GET']
 )
+gameweek_fantasy_stats_view = GameWeekStatsFantasyView.as_view(
+    'gameweek_stats_fantasy_api')
 gameweek_stats_blueprint.add_url_rule(
-    '/gameweek_stats/<game_week_id>/<fantasy_team_id>',
-    view_func=gameweek_stats_view, methods=['GET']
+    '/gameweek_stats/<game_week_id>/fantasy_team/<fantasy_team_id>',
+    view_func=gameweek_fantasy_stats_view, methods=['GET']
 )
 gameweek_stats_blueprint.add_url_rule(
-    '/gameweek_stats/<game_week_id>/<player_id>', view_func=gameweek_stats_view,
-    methods=['GET', 'POST', 'PUT', 'DELETE']
+    '/gameweek_stats/<game_week_id>/player/<player_id>',
+    view_func=gameweek_stats_view, methods=['GET', 'POST', 'PUT', 'DELETE']
 )
 
 team_of_the_week_view = TeamOfWeekView.as_view('team_of_the_week_api')

--- a/api/gameweek_stats/helpers.py
+++ b/api/gameweek_stats/helpers.py
@@ -42,7 +42,8 @@ def get_fantasy_player_stats(fantasy_team_players, game_week_id):
     for fantasy_team_player in fantasy_team_players:
         player = PlayerGameWeek.filter_by(
             player_id=fantasy_team_player.id, game_week_id=game_week_id).all()
-        player_stats.append(player[0].serialize())
+        if player:
+            player_stats.append(player[0].serialize())
     return player_stats
 
 

--- a/api/gameweek_stats/views.py
+++ b/api/gameweek_stats/views.py
@@ -14,9 +14,7 @@ class GameWeekStatsView(MethodView):
     """
 
     @token_required
-    def get(
-        self, current_user, game_week_id, player_id=None, fantasy_team_id=None
-    ):
+    def get(self, current_user, game_week_id, player_id=None):
         game_week = GameWeek.find_first(id=game_week_id)
         if not game_week:
             response = {
@@ -24,18 +22,6 @@ class GameWeekStatsView(MethodView):
                 'message': 'GameWeek does not exist'
             }
             return make_response(jsonify(response)), 404
-
-        if fantasy_team_id:
-            fantasy_team = FantasyTeam.find_first(id=fantasy_team_id)
-            fantasy_team_players = fantasy_team.players
-            fantasy_team_player_stats = get_fantasy_player_stats(
-                fantasy_team_players, game_week_id)
-
-            response = {
-                'status': 'success',
-                'fantasy_team_stats': fantasy_team_player_stats
-            }
-            return make_response(jsonify(response)), 200
 
         if player_id:
             player_stats = PlayerGameWeek.filter_by(
@@ -136,6 +122,42 @@ class GameWeekStatsView(MethodView):
                 'message': 'Failed to update gameweek stats.'
             }
             return make_response(jsonify(response)), 500
+
+
+class GameWeekStatsFantasyView(MethodView):
+    """
+    View to handle GameWeek fantasy team stats
+    """
+
+    @token_required
+    def get(self, current_user, game_week_id, fantasy_team_id):
+        game_week = GameWeek.find_first(id=game_week_id)
+        if not game_week:
+            response = {
+                'status': 'fail',
+                'message': 'GameWeek does not exist'
+            }
+            return make_response(jsonify(response)), 404
+
+        fantasy_team = FantasyTeam.find_first(id=fantasy_team_id)
+
+        if not fantasy_team or not fantasy_team.players:
+            response = {
+                'status': 'fail',
+                'message': 'FantasyTeam does not exist or does not have players.'
+            }
+            return make_response(jsonify(response)), 404
+
+        fantasy_team = FantasyTeam.find_first(id=fantasy_team_id)
+        fantasy_team_players = fantasy_team.players
+        fantasy_team_player_stats = get_fantasy_player_stats(
+            fantasy_team_players, game_week_id)
+
+        response = {
+            'status': 'success',
+            'fantasy_team_stats': fantasy_team_player_stats
+        }
+        return make_response(jsonify(response)), 200
 
 
 class TeamOfWeekView(MethodView):


### PR DESCRIPTION
Initially, the same endpoint was hit causing a few issues for certain edge cases.

****What this PR does?****
Creates separates endpoints for viewing `stats/performance` of a `player` and a `fantasy team` for a particular game-week.