### PR TITLE
Fix delete team not working issue

### DIFF
--- a/api/models/team.py
+++ b/api/models/team.py
@@ -14,6 +14,4 @@ class Team(ModelMixin):
     manager = db.Column(db.String(180))
     jersey = db.Column(db.String(180))
     players = db.relationship(
-        "Player", backref="team", lazy="dynamic")
-    season = db.relationship(
-        "Season", secondary="season_teams", lazy="dynamic")
+        "Player", backref="teams", lazy="dynamic")


### PR DESCRIPTION
Fix bug where deleting a team returns success but the team is not deleted from the database.