### PR TITLE
Fix Player Team DB relationship

### DIFF
--- a/api/models/team.py
+++ b/api/models/team.py
@@ -14,4 +14,4 @@ class Team(ModelMixin):
     manager = db.Column(db.String(180))
     jersey = db.Column(db.String(180))
     players = db.relationship(
-        "Player", backref="teams", lazy="dynamic")
+        "Player", backref="team", lazy="dynamic")


### PR DESCRIPTION
Fix an issue where fetching fantasy team players returns an error due to wrong relationship reference in the DB.